### PR TITLE
fix: construct rclcpp::Time before adding a Duration in the event-based camera publisher

### DIFF
--- a/src/stonefish_ros2/ROS2Interface.cpp
+++ b/src/stonefish_ros2/ROS2Interface.cpp
@@ -694,7 +694,7 @@ void ROS2Interface::PublishEventBasedCamera(rclcpp::PublisherBase::SharedPtr pub
         msg.events[i].x = (unsigned int)(data[i*2] >> 16);
         msg.events[i].y = (unsigned int)(data[i*2] & 0xFFFF); 
         //Next 4 bytes - polarity and time
-        msg.events[i].ts = msg.header.stamp + rclcpp::Duration(0, abs(data[i*2+1]));
+        msg.events[i].ts = rclcpp::Time(msg.header.stamp) + rclcpp::Duration(0, abs(data[i*2+1]));
         msg.events[i].polarity = data[i*2+1] > 0;
     }
     std::static_pointer_cast<rclcpp::Publisher<stonefish_ros2::msg::EventArray>>(pub)->publish(msg);


### PR DESCRIPTION
`ROS2Interface::PublishEventBasedCamera` adds an `rclcpp::Duration` directly to `msg.header.stamp`, which is a `builtin_interfaces::msg::Time`.

Works on ROS 2 Jazzy but crashes on **Humble**

```
no match for 'operator+' (operand types are 'builtin_interfaces::msg::Time' and 'rclcpp::Duration')
```

Construct an `rclcpp::Time` from the stamp explicitly before adding the per-event offset.